### PR TITLE
Close #16: Created Issue Templates for Bugs and Enhancements

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,22 @@
+---
+name: Bug report
+about: Ran into a bug? Create a report to bring attention to it.
+title: ''
+labels: ['bug']
+assignees: ''
+---
+
+## Description:
+<!-- Please provide a clear description explaining the bug -->
+
+## Steps to Reproduce:
+<!-- Please provide clear and easy-to-follow instructions to reproduce the bug-->
+
+## Expected vs Actual Behaviour:
+<!-- What was the intended behaviour you expect, and how it differs to what occurred? -->
+
+## Screenshots:
+<!-- Feel free to attach screenshots to visually explain the bug -->
+
+## Additional Info:
+<!-- Add any additional info here relevenat to the bug -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/enhancement_request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement_request.md
@@ -1,0 +1,17 @@
+---
+name: Enhancement Request
+about: Suggest an enhancement to this project.
+title: ''
+labels: ['enhancement']
+assignees: ''
+---
+
+## Motivation
+<!-- Please explain your initial motivations for suggesting your feature -->
+<!-- e.g. Is any documentation lacking in detial? Is there something missng that should be addressed? -->
+
+## Enhancement Proposal
+<!-- Please explain your proposed enhancement to this project -->
+
+## Purpose
+<!-- Please explain how your proposed enhancement aims to improve this project -->


### PR DESCRIPTION
In this PR, I have created issue templates `bug_report.md` and `enhancement_request.md` located in a new directory `/.github/ISSUE_TEMPLATE/`. I have also created `config.yml` located in the same directory to enforce contributors to use a template.
Closes #16 
